### PR TITLE
fix: move endpoint validation to first request with retry logic

### DIFF
--- a/terratunnel/client/app.py
+++ b/terratunnel/client/app.py
@@ -237,7 +237,8 @@ class TunnelClient:
                     url=url,
                     headers=headers,
                     params=query_params,
-                    content=body
+                    content=body,
+                    timeout=30.0  # 30 second timeout
                 )
                 
                 response_data = {


### PR DESCRIPTION
- Remove server-side validation immediately after hostname assignment
- Add validation on first request with 3 retry attempts and exponential backoff
- Track validation state per subdomain to avoid re-validation
- Remove client-side retry logic (only needed for validation)
- Allow local endpoints to start after tunnel connection is established

This fixes the issue where clients would disconnect immediately after receiving hostname assignment due to validation failures when the local endpoint wasn't ready yet.