### PR TITLE
Fix database path for Fly.io deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ ENV PYTHONUNBUFFERED=1 \
 # Create non-root user for security
 RUN addgroup -S terratunnel && adduser -S terratunnel -G terratunnel
 
+# Create data directory for persistent storage
+RUN mkdir -p /data && chown terratunnel:terratunnel /data
+
 # Install runtime dependencies only
 RUN apk add --no-cache libffi
 

--- a/fly.toml
+++ b/fly.toml
@@ -20,6 +20,7 @@ primary_region = 'iad'
   JWT_ALGORITHM = 'HS256'
   JWT_EXPIRATION_HOURS = '24'
   TERRATUNNEL_GITHUB_ADMIN_USERS = 'joshpollara'
+  TERRATUNNEL_DB_PATH = '/data/terratunnel.db'
 
 [http_service]
   internal_port = 8000
@@ -74,3 +75,7 @@ primary_region = 'iad'
   memory = '256mb'
   cpu_kind = 'shared'
   cpus = 1
+
+[mounts]
+  source = 'terratunnel_data'
+  destination = '/data'


### PR DESCRIPTION
- Set TERRATUNNEL_DB_PATH to /data/terratunnel.db in fly.toml
- Add volume mount for persistent storage at /data
- Create /data directory in Dockerfile with proper permissions
- Ensure terratunnel user has write access to /data directory

This fixes the sqlite3.OperationalError on Fly.io by using a writable directory for the database file.

🤖 Generated with [Claude Code](https://claude.ai/code)