### PR TITLE
Add GitLab OAuth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@
 GITHUB_CLIENT_ID=your_github_client_id_here
 GITHUB_CLIENT_SECRET=your_github_client_secret_here
 
+# GitLab OAuth App credentials
+# Create a GitLab OAuth App at: https://gitlab.com/-/profile/applications
+# Set Redirect URI to: https://yourdomain.com/auth/gitlab/callback
+# Required scopes: read_user
+GITLAB_CLIENT_ID=your_gitlab_client_id_here
+GITLAB_CLIENT_SECRET=your_gitlab_client_secret_here
+
 # JWT Configuration
 # Generate a secure secret: openssl rand -hex 32
 JWT_SECRET=your_jwt_secret_here

--- a/terratunnel/server/app.py
+++ b/terratunnel/server/app.py
@@ -1773,12 +1773,28 @@ async def home_page(request: Request, auth_token: Optional[str] = Cookie(None)):
                 
                 <p>Sign in to get started with your API key.</p>
                 
-                <a href="/auth/github?redirect_uri=/" class="github-button">
-                    <svg height="20" width="20" viewBox="0 0 16 16" fill="white">
-                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                    </svg>
-                    Sign in with GitHub
-                </a>
+                <div style="display: flex; gap: 10px; justify-content: center; flex-wrap: wrap;">"""
+        
+        if Config.has_github_oauth():
+            html += """
+                    <a href="/auth/github?redirect_uri=/" class="github-button">
+                        <svg height="20" width="20" viewBox="0 0 16 16" fill="white">
+                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                        </svg>
+                        Sign in with GitHub
+                    </a>"""
+        
+        if Config.has_gitlab_oauth():
+            html += """
+                    <a href="/auth/gitlab?redirect_uri=/" class="gitlab-button" style="background: #FC6D26; display: inline-flex; align-items: center; gap: 10px; padding: 12px 24px; color: white; border: none; border-radius: 6px; text-decoration: none; font-size: 16px; margin-top: 20px; cursor: pointer;">
+                        <svg height="20" width="20" viewBox="0 0 24 24" fill="white">
+                            <path d="M23.6 9.593l-.033-.086L20.3.98a.851.851 0 00-.336-.405.875.875 0 00-1.073.174.875.875 0 00-.2.395l-2.18 6.7H7.495l-2.18-6.7a.875.875 0 00-.2-.395.875.875 0 00-1.073-.174.851.851 0 00-.336.405L.437 9.506l-.032.086a6.066 6.066 0 002.27 7.202l.004.003.01.008 4.988 3.73 2.462 1.862 1.5 1.134a1.008 1.008 0 001.22 0l1.5-1.134 2.462-1.862 4.997-3.739.01-.008a6.068 6.068 0 002.263-7.196z"/>
+                        </svg>
+                        Sign in with GitLab
+                    </a>"""
+        
+        html += """
+                </div>
             </div>
         </body>
         </html>
@@ -1795,7 +1811,7 @@ async def new_tunnel_page(request: Request, auth_token: Optional[str] = Cookie(N
     
     user = await get_current_user_from_cookie(request, auth_token)
     if not user:
-        return RedirectResponse(url="/auth/github?redirect_uri=/tunnels/new", status_code=302)
+        return RedirectResponse(url="/auth/login?redirect_uri=/tunnels/new", status_code=302)
     
     # Check if user is admin
     if not is_admin_user(user):
@@ -1878,7 +1894,7 @@ async def new_tunnel_api_key_page(tunnel_id: int, request: Request, auth_token: 
     
     user = await get_current_user_from_cookie(request, auth_token)
     if not user:
-        return RedirectResponse(url=f"/auth/github?redirect_uri=/tunnels/{tunnel_id}/keys/new", status_code=302)
+        return RedirectResponse(url=f"/auth/login?redirect_uri=/tunnels/{tunnel_id}/keys/new", status_code=302)
     
     # Verify user owns this tunnel
     if db:
@@ -1998,7 +2014,7 @@ async def new_api_key_page(request: Request, auth_token: Optional[str] = Cookie(
     
     user = await get_current_user_from_cookie(request, auth_token)
     if not user:
-        return RedirectResponse(url="/auth/github?redirect_uri=/api/keys/new", status_code=302)
+        return RedirectResponse(url="/auth/login?redirect_uri=/api/keys/new", status_code=302)
     
     # Check if user already has an API key
     has_api_key = False
@@ -2170,7 +2186,7 @@ async def generate_api_key(request: Request, auth_token: Optional[str] = Cookie(
     
     user = await get_current_user_from_cookie(request, auth_token)
     if not user:
-        return RedirectResponse(url="/auth/github?redirect_uri=/api/keys/new", status_code=302)
+        return RedirectResponse(url="/auth/login?redirect_uri=/api/keys/new", status_code=302)
     
     # Get form data
     form_data = await request.form()
@@ -2349,7 +2365,7 @@ async def revoke_api_key(key_id: int, request: Request, auth_token: Optional[str
     
     user = await get_current_user_from_cookie(request, auth_token)
     if not user:
-        return RedirectResponse(url="/auth/github?redirect_uri=/", status_code=302)
+        return RedirectResponse(url="/auth/login?redirect_uri=/", status_code=302)
     
     if db:
         # Verify the key belongs to the user and revoke it

--- a/terratunnel/server/auth.py
+++ b/terratunnel/server/auth.py
@@ -382,14 +382,40 @@ async def github_oauth_callback(
 
 @auth_router.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request, redirect_uri: Optional[str] = None):
-    """Simple login page with GitHub OAuth button"""
-    if not Config.has_github_oauth():
-        return HTMLResponse("<h1>OAuth not configured</h1><p>GitHub OAuth is not configured on this server.</p>", status_code=503)
+    """Simple login page with OAuth provider buttons"""
+    if not Config.has_any_oauth():
+        return HTMLResponse("<h1>OAuth not configured</h1><p>No OAuth provider is configured on this server.</p>", status_code=503)
     
-    # Build the GitHub auth URL
-    github_url = str(request.url_for("github_oauth_redirect"))
-    if redirect_uri:
-        github_url += f"?redirect_uri={redirect_uri}"
+    # Build OAuth URLs
+    oauth_buttons = []
+    
+    if Config.has_github_oauth():
+        github_url = str(request.url_for("github_oauth_redirect"))
+        if redirect_uri:
+            github_url += f"?redirect_uri={redirect_uri}"
+        oauth_buttons.append(f'''
+            <a href="{github_url}" class="oauth-button github-button">
+                <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
+                Sign in with GitHub
+            </a>
+        ''')
+    
+    if Config.has_gitlab_oauth():
+        gitlab_url = str(request.url_for("gitlab_oauth_redirect"))
+        if redirect_uri:
+            gitlab_url += f"?redirect_uri={redirect_uri}"
+        oauth_buttons.append(f'''
+            <a href="{gitlab_url}" class="oauth-button gitlab-button">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M23.6 9.593l-.033-.086L20.3.98a.851.851 0 00-.336-.405.875.875 0 00-1.073.174.875.875 0 00-.2.395l-2.18 6.7H7.495l-2.18-6.7a.875.875 0 00-.2-.395.875.875 0 00-1.073-.174.851.851 0 00-.336.405L.437 9.506l-.032.086a6.066 6.066 0 002.27 7.202l.004.003.01.008 4.988 3.73 2.462 1.862 1.5 1.134a1.008 1.008 0 001.22 0l1.5-1.134 2.462-1.862 4.997-3.739.01-.008a6.068 6.068 0 002.263-7.196z"/>
+                </svg>
+                Sign in with GitLab
+            </a>
+        ''')
+    
+    buttons_html = '\n'.join(oauth_buttons)
     
     html = f"""
     <!DOCTYPE html>
@@ -422,21 +448,33 @@ async def login_page(request: Request, redirect_uri: Optional[str] = None):
                 color: #666;
                 margin-bottom: 30px;
             }}
-            .github-button {{
+            .oauth-button {{
                 display: inline-flex;
                 align-items: center;
                 padding: 12px 24px;
-                background: #24292e;
                 color: white;
                 text-decoration: none;
                 border-radius: 6px;
                 font-weight: 500;
                 transition: background 0.2s;
+                margin: 5px 0;
+                width: 100%;
+                justify-content: center;
+                box-sizing: border-box;
+            }}
+            .github-button {{
+                background: #24292e;
             }}
             .github-button:hover {{
                 background: #1a1e22;
             }}
-            .github-button svg {{
+            .gitlab-button {{
+                background: #FC6D26;
+            }}
+            .gitlab-button:hover {{
+                background: #E24329;
+            }}
+            .oauth-button svg {{
                 margin-right: 8px;
             }}
         </style>
@@ -445,17 +483,307 @@ async def login_page(request: Request, redirect_uri: Optional[str] = None):
         <div class="login-container">
             <h1>🚇 Terratunnel</h1>
             <p>Sign in to manage your tunnels</p>
-            <a href="{github_url}" class="github-button">
-                <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
-                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
-                </svg>
-                Sign in with GitHub
-            </a>
+            {buttons_html}
         </div>
     </body>
     </html>
     """
     return HTMLResponse(content=html)
+
+
+@auth_router.get("/gitlab")
+async def gitlab_oauth_redirect(request: Request, redirect_uri: Optional[str] = None):
+    """Redirect to GitLab OAuth authorization page"""
+    if not Config.has_gitlab_oauth():
+        raise HTTPException(status_code=503, detail="GitLab OAuth not configured")
+    
+    # Generate state for CSRF protection
+    state = generate_state()
+    
+    # Store redirect URI in state data if provided
+    if redirect_uri:
+        oauth_states[f"{state}_redirect"] = redirect_uri
+    
+    # Get the server's domain from request
+    host = request.headers.get("host", "localhost")
+    is_https = request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https"
+    callback_uri = Config.get_gitlab_oauth_redirect_uri(host, is_https)
+    
+    # Build GitLab OAuth URL
+    gitlab_oauth_url = "https://gitlab.com/oauth/authorize"
+    params = {
+        "client_id": Config.GITLAB_CLIENT_ID,
+        "redirect_uri": callback_uri,
+        "response_type": "code",
+        "scope": "read_user",
+        "state": state
+    }
+    
+    authorization_url = f"{gitlab_oauth_url}?{urlencode(params)}"
+    return RedirectResponse(url=authorization_url, status_code=302)
+
+
+@auth_router.get("/gitlab/authorize")
+async def gitlab_oauth_authorize_proxy(
+    request: Request,
+    redirect_uri: str,
+    state: Optional[str] = None
+):
+    """OAuth proxy endpoint for third-party integrations"""
+    if not Config.has_gitlab_oauth():
+        raise HTTPException(status_code=503, detail="GitLab OAuth not configured")
+    
+    # Log the incoming request
+    import logging
+    logger = logging.getLogger("terratunnel-server")
+    logger.info(f"GitLab OAuth proxy request: redirect_uri={redirect_uri}, external_state={state}")
+    
+    # Store the external redirect URI and state for later
+    internal_state = generate_state()
+    logger.info(f"Generated internal state: {internal_state}")
+    
+    # Store both the external redirect_uri and external state
+    oauth_states[f"{internal_state}_external_redirect"] = redirect_uri
+    if state:
+        oauth_states[f"{internal_state}_external_state"] = state
+    
+    # Get the server's domain from request
+    host = request.headers.get("host", "localhost")
+    is_https = request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https"
+    callback_uri = Config.get_gitlab_oauth_redirect_uri(host, is_https)
+    
+    # Build GitLab OAuth URL with our internal callback
+    gitlab_oauth_url = "https://gitlab.com/oauth/authorize"
+    params = {
+        "client_id": Config.GITLAB_CLIENT_ID,
+        "redirect_uri": callback_uri,
+        "response_type": "code",
+        "scope": "read_user",
+        "state": internal_state
+    }
+    
+    authorization_url = f"{gitlab_oauth_url}?{urlencode(params)}"
+    return RedirectResponse(url=authorization_url, status_code=302)
+
+
+@auth_router.get("/gitlab/callback")
+async def gitlab_oauth_callback(
+    request: Request,
+    code: str,
+    state: str,
+    error: Optional[str] = None,
+    error_description: Optional[str] = None
+):
+    """Handle OAuth callback from GitLab"""
+    # Log the callback
+    import logging
+    logger = logging.getLogger("terratunnel-server")
+    logger.info(f"GitLab OAuth callback received: code={code[:10] if code else None}..., state={state}, error={error}")
+    
+    # Check for OAuth errors first
+    if error:
+        # Check if this is an external OAuth proxy request that had an error
+        external_redirect_uri = oauth_states.get(f"{state}_external_redirect")
+        if external_redirect_uri:
+            # Get external state before cleaning up
+            external_state_err = oauth_states.get(f"{state}_external_state")
+            
+            # Clean up state
+            oauth_states.pop(f"{state}_external_redirect", None)
+            oauth_states.pop(f"{state}_external_state", None)
+            
+            # Redirect back to external service with error
+            error_params = {
+                "error": error,
+                "error_description": error_description or "OAuth authorization failed"
+            }
+            if external_state_err:
+                error_params["state"] = external_state_err
+            
+            redirect_url = f"{external_redirect_uri}?{urlencode(error_params)}"
+            return RedirectResponse(url=redirect_url, status_code=302)
+        else:
+            # Normal error handling
+            error_msg = f"OAuth error: {error}"
+            if error_description:
+                error_msg += f" - {error_description}"
+            raise HTTPException(status_code=400, detail=error_msg)
+    
+    # Verify state parameter (don't delete yet, we need it for external redirect info)
+    if not verify_state(state, delete=False):
+        raise HTTPException(status_code=400, detail="Invalid or expired state parameter")
+    
+    # Exchange code for access token
+    token_url = "https://gitlab.com/oauth/token"
+    
+    # Get the callback URI that was used
+    host = request.headers.get("host", "localhost")
+    is_https = request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https"
+    callback_uri = Config.get_gitlab_oauth_redirect_uri(host, is_https)
+    
+    data = {
+        "client_id": Config.GITLAB_CLIENT_ID,
+        "client_secret": Config.GITLAB_CLIENT_SECRET,
+        "code": code,
+        "grant_type": "authorization_code",
+        "redirect_uri": callback_uri
+    }
+    
+    headers = {
+        "Accept": "application/json"
+    }
+    
+    async with httpx.AsyncClient() as client:
+        # Get access token
+        token_response = await client.post(token_url, data=data, headers=headers)
+        token_data = token_response.json()
+        
+        if "error" in token_data:
+            raise HTTPException(
+                status_code=400, 
+                detail=f"Failed to get access token: {token_data.get('error_description', token_data['error'])}"
+            )
+        
+        access_token = token_data.get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=400, detail="No access token received")
+        
+        # Get user info from GitLab
+        user_response = await client.get(
+            "https://gitlab.com/api/v4/user",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/json"
+            }
+        )
+        
+        if user_response.status_code != 200:
+            raise HTTPException(status_code=400, detail="Failed to get user info from GitLab")
+        
+        gitlab_user = user_response.json()
+    
+    # Create or update user in database
+    db = get_database()
+    user_id = db.create_or_update_user(
+        auth_provider="gitlab",
+        provider_user_id=str(gitlab_user["id"]),
+        provider_username=gitlab_user["username"],
+        email=gitlab_user.get("email"),
+        name=gitlab_user.get("name"),
+        avatar_url=gitlab_user.get("avatar_url")
+    )
+    
+    # Create JWT token
+    user = db.get_user_by_id(user_id)
+    jwt_payload = {
+        "sub": str(user_id),
+        "provider": "gitlab",
+        "username": user["provider_username"],
+        "exp": datetime.now(timezone.utc) + timedelta(hours=Config.JWT_EXPIRATION_HOURS),
+        "iat": datetime.now(timezone.utc)
+    }
+    
+    jwt_token = jwt.encode(jwt_payload, Config.JWT_SECRET, algorithm=Config.JWT_ALGORITHM)
+    
+    # Check if there was a redirect URI stored (normal auth flow)
+    redirect_uri = oauth_states.pop(f"{state}_redirect", None)
+    
+    # Check if this is an external OAuth proxy request (from /auth/gitlab/authorize)
+    external_redirect_uri = oauth_states.pop(f"{state}_external_redirect", None)
+    external_state = oauth_states.pop(f"{state}_external_state", None)
+    
+    # Now we can safely delete the state since we've retrieved all associated data
+    oauth_states.pop(state, None)
+    
+    if external_redirect_uri:
+        # This is from the OAuth proxy - create tunnel and redirect back with all data
+        try:
+            # Check if user is admin
+            is_admin = Config.is_admin_user("gitlab", user["provider_username"])
+            
+            # Create API key for the user (this will also create a tunnel if needed)
+            api_key = db.create_api_key(
+                user_id=user_id,
+                name=f"Terrateam Setup Wizard - {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+                is_admin=is_admin,
+                provider="gitlab",
+                username=user["provider_username"]
+            )
+            
+            # Get the actual tunnel that was created/used for this API key
+            api_key_info = db.validate_api_key(api_key)
+            if api_key_info and api_key_info.get("tunnel_subdomain"):
+                tunnel_subdomain = api_key_info["tunnel_subdomain"]
+            else:
+                # Fallback - this shouldn't happen
+                logger.error(f"Could not get tunnel subdomain for API key")
+                raise Exception("Failed to get tunnel information")
+            
+            # Get the tunnel URL - extract domain from the Host header
+            host = request.headers.get("host", "localhost")
+            # Remove port if present
+            domain = host.split(':')[0]
+            tunnel_url = f"https://{tunnel_subdomain}.{domain}"
+            
+            # Log tunnel creation details
+            logger.info(f"Created tunnel for user {gitlab_user['username']}: {tunnel_url} (API key: {api_key[:8]}...)")
+            
+            # Build redirect URL with all required parameters
+            params = {
+                "access_token": access_token,  # GitLab access token
+                "user_login": gitlab_user["username"],
+                "user_id": str(gitlab_user["id"]),
+                "tunnel_id": tunnel_subdomain,
+                "tunnel_url": tunnel_url,
+                "api_key": api_key
+            }
+            
+            # Add the original state if it was provided
+            if external_state:
+                params["state"] = external_state
+            
+            redirect_url = f"{external_redirect_uri}?{urlencode(params)}"
+            
+            # Log the callback for debugging
+            logger.info(f"GitLab OAuth proxy callback: redirecting to {redirect_url}")
+            
+            return RedirectResponse(url=redirect_url, status_code=302)
+            
+        except Exception as e:
+            # Handle errors by redirecting back with error parameters
+            error_params = {
+                "error": "tunnel_creation_failed",
+                "error_description": f"Failed to create tunnel: {str(e)}"
+            }
+            if external_state:
+                error_params["state"] = external_state
+            
+            redirect_url = f"{external_redirect_uri}?{urlencode(error_params)}"
+            return RedirectResponse(url=redirect_url, status_code=302)
+    
+    elif redirect_uri:
+        # Normal browser-based auth - set cookie and redirect
+        response = RedirectResponse(url=redirect_uri, status_code=302)
+        response.set_cookie(
+            key="auth_token",
+            value=jwt_token,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=Config.JWT_EXPIRATION_HOURS * 3600
+        )
+        return response
+    else:
+        # API-based auth - return JSON with token
+        return JSONResponse({
+            "token": jwt_token,
+            "user": {
+                "id": user_id,
+                "username": user["provider_username"],
+                "email": user["email"],
+                "avatar_url": user["avatar_url"]
+            }
+        })
 
 
 @auth_router.get("/logout")


### PR DESCRIPTION
- Add GitLab as an OAuth provider alongside GitHub
- Support GITLAB_CLIENT_ID and GITLAB_CLIENT_SECRET configuration
- Add TERRATUNNEL_GITLAB_ADMIN_USERS for GitLab admin access control
- Update documentation with GitLab OAuth setup instructions
- Add linting commands to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)